### PR TITLE
Fixed “Cutoff targets” in PNG Info to show all tokens

### DIFF
--- a/scripts/cutoff.py
+++ b/scripts/cutoff.py
@@ -268,7 +268,7 @@ class Script(scripts.Script):
         
         p.extra_generation_params.update({
             f'{NAME} enabled': enabled,
-            f'{NAME} targets': targets,
+            f'{NAME} targets': targets_,
             f'{NAME} padding': padding,
             f'{NAME} weight': weight,
             f'{NAME} disable_for_neg': disable_neg,


### PR DESCRIPTION
Target tokensに記述したトークンのうち、最初の一つだけがPNG Infoに記載されるという現象が発生していたので、すべて記載されるように変更しました。
Only the first one of the tokens described in the Target tokens was listed in PNG Info, so I changed the code so that all of those tokens are listed.